### PR TITLE
Fix issue with class_attribute that breaks in rails 4.0

### DIFF
--- a/lib/figleaf/settings.rb
+++ b/lib/figleaf/settings.rb
@@ -1,9 +1,9 @@
 module Figleaf
   class Settings
-    class << self
-      class_attribute :auto_define
-      self.auto_define = false
+    class_attribute :auto_define
+    self.auto_define = false
 
+    class << self
       # Public - configure pre-defined attributes
       #
       def configure

--- a/lib/figleaf/version.rb
+++ b/lib/figleaf/version.rb
@@ -1,3 +1,3 @@
 module Figleaf
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
We encountered a weird error that only appears on Rails 4.0. Not sure why the tests pass as I believe the change below is semantically correct.
